### PR TITLE
use specific version of iOSMcuManagerLibrary

### DIFF
--- a/ios/mcumgr_flutter.podspec
+++ b/ios/mcumgr_flutter.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'iOSMcuManagerLibrary', '~> 1.3'
+  s.dependency 'iOSMcuManagerLibrary', '1.3.3'
   s.dependency 'SwiftProtobuf'
   s.platform = :ios, '13.0'
 


### PR DESCRIPTION
Regarding this issue: https://github.com/NordicSemiconductor/Flutter-nRF-Connect-Device-Manager/issues/38
In order to prevent such problems in the future I propose to indicate the **exact version** of the package, and not to use an **optimistic operator** 