### PR TITLE
bugfix: Missing call to start single image firmware update on android

### DIFF
--- a/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
+++ b/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
@@ -72,6 +72,7 @@ class McumgrFlutterPlugin : FlutterPlugin, MethodCallHandler {
 					result.success(null)
 				}
 				FlutterMethod.updateSingleImage -> {
+					updateSingleImage(call)
 					result.success(null)
 				}
 				FlutterMethod.pause -> {


### PR DESCRIPTION
The logic to start the firmware update with a single image is not called in the android method channel.