### PR TITLE
bugfix: Crash on iOS for invalid parameter in FlutterError

### DIFF
--- a/ios/Classes/SwiftMcumgrFlutterPlugin.swift
+++ b/ios/Classes/SwiftMcumgrFlutterPlugin.swift
@@ -103,15 +103,15 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
     
     private func initializeUpdateManager(call: FlutterMethodCall) throws {
         guard let uuidString = call.arguments as? String, let uuid = UUID(uuidString: uuidString) else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not create UUID from provided arguments", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not create UUID from provided arguments", details: nil)
         }
         
         guard let peripheral = centralManager.retrievePeripherals(withIdentifiers: [uuid]).first else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can't retrieve peripheral with provided UUID", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can't retrieve peripheral with provided UUID", details: nil)
         }
         
         guard case .none = updateManagers[uuidString] else {
-            throw FlutterError(code: ErrorCode.updateManagerExists.rawValue, message: "Updated manager for provided peripheral already exists", details: call)
+            throw FlutterError(code: ErrorCode.updateManagerExists.rawValue, message: "Updated manager for provided peripheral already exists", details: nil)
         }
         
         let logger = UpdateLogger(identifier: uuidString, streamHandler: logStreamHandler)
@@ -121,11 +121,11 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
     
     private func retrieveManager(call: FlutterMethodCall) throws -> UpdateManager {
         guard let uuid = call.arguments as? String else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can't retrieve UUID of the device", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can't retrieve UUID of the device", details: nil)
         }
 
         guard let manager = updateManagers[uuid] else {
-            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call)
+            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: nil)
         }
 
         return manager;
@@ -153,12 +153,12 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
     
     private func update(call: FlutterMethodCall) throws {
         guard let data = call.arguments as? FlutterStandardTypedData else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: nil)
         }
         
         let args = try ProtoUpdateWithImageCallArguments(serializedData: data.data)
         guard let manager = updateManagers[args.deviceUuid] else {
-            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call)
+            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: nil)
         }
         
         let images = args.images.map { (Int($0.key), $0.value) }
@@ -169,12 +169,12 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
     
     private func updateSingleImage(call: FlutterMethodCall) throws {
         guard let data = call.arguments as? FlutterStandardTypedData else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: nil)
         }
         
         let args = try ProtoUpdateCallArgument(serializedData: data.data)
         guard let manager = updateManagers[args.deviceUuid] else {
-            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call)
+            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: nil)
         }
         
         try manager.update(data: args.firmwareData)
@@ -188,12 +188,12 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
     // MARK: Logs 
     private func readLogs(call: FlutterMethodCall) throws -> ProtoReadMessagesResponse {
         guard let data = call.arguments as? FlutterStandardTypedData else {
-            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: call)
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse provided arguments", details: nil)
         }
         
         let args = try ProtoReadLogCallArguments(serializedData: data.data)
         guard let manager = updateManagers[args.uuid] else {
-            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call)
+            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: nil)
         }
         
         return manager.updateLogger.readLogs()


### PR DESCRIPTION
The FlutterError(code:message:details) constructor expects a nullable string for the details parameter. As the FlutterMethodCall is passed here this leads to an error while serializing the error to transfer it to the flutter backend crashing the app:

```
Unsupported value: <FlutterMethodCall: 0x2812fdd20> of type FlutterMethodCall
*** Assertion failure in void WriteValueOfType(CFTypeRef, CFMutableDataRef, FlutterStandardCodecObjcType, CFTypeRef)(), FlutterStandardCodec.mm:341
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Unsupported value for standard codec'
*** First throw call stack:
(0x1af4dd40c 0x1a87bdc28 0x1a9cc49d4 0x1062fa22c 0x1062f9d88 0x1062fb124 0x1062f58b8 0x1027949d0 0x102796380 0x10279660c 0x1062f5630 0x105d51644 0x1b62817a8 0x1b6282780 0x1b6263e10 0x1b6263a88 0x1af5659ac 0x1af549648 0x1af54dd20 0x1e7619998 0x1b17e080c 0x1b17e0484 0x1023d5688 0x1ccd04344)
libc++abi: terminating due to uncaught exception of type NSException
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00000001eacfa198 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x1eacfa198 <+8>:  b.lo   0x1eacfa1b4               ; <+36>
    0x1eacfa19c <+12>: stp    x29, x30, [sp, #-0x10]!
    0x1eacfa1a0 <+16>: mov    x29, sp
    0x1eacfa1a4 <+20>: bl     0x1eacf5b70               ; cerror_nocancel
Target 0: (Runner) stopped.
Lost connection to device.
the Dart compiler exited unexpectedly.
```