### PR TITLE
Feature/config for single image update

### DIFF
--- a/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
+++ b/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
@@ -176,7 +176,29 @@ class McumgrFlutterPlugin : FlutterPlugin, MethodCallHandler {
 		}
 		val image = args.firmware_data.toByteArray()
 
-		updateManager.start(args.firmware_data.toByteArray())
+		val config = args.configuration?.let { config ->
+			return@let FirmwareUpgradeConfiguration(
+				config.estimatedSwapTimeMs,
+				config.eraseAppSettings,
+				config.pipelineDepth.toInt(),
+				when (config.byteAlignment) {
+					ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment.TWO_BYTE -> 2
+					ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment.FOUR_BYTE -> 4
+					ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment.EIGHT_BYTE -> 8
+					ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment.SIXTEEN_BYTE -> 16
+					ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment.DISABLED -> 0
+				},
+				config.reassemblyBufferSize,
+				when (config.firmwareUpgradeMode) {
+					ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode.TEST_ONLY -> FirmwareUpgradeManager.Mode.TEST_ONLY
+					ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode.TEST_AND_CONFIRM -> FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM
+					ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode.CONFIRM_ONLY -> FirmwareUpgradeManager.Mode.CONFIRM_ONLY
+					ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode.UPLOAD_ONLY -> FirmwareUpgradeManager.Mode.NONE
+				}
+			)
+		}
+
+		updateManager.start(args.firmware_data.toByteArray(), config)
 	}
 
 	@Throws(FlutterError::class)

--- a/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/UpdateManager.kt
+++ b/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/UpdateManager.kt
@@ -3,6 +3,7 @@ package no.nordicsemi.android.mcumgr_flutter
 import android.util.Log
 import android.util.Pair
 import io.runtime.mcumgr.ble.McuMgrBleTransport
+import io.runtime.mcumgr.dfu.model.McuMgrImageSet;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeCallback
 import io.runtime.mcumgr.dfu.FirmwareUpgradeController
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager
@@ -83,8 +84,14 @@ class UpdateManager(
 		manager.start(images, config?.eraseAppSettings ?: true)
 	}
 
-	fun start(imageData: ByteArray) {
-		manager.start(imageData)
+	fun start(imageData: ByteArray, config: FirmwareUpgradeConfiguration?) {
+		if (config != null) {
+			manager.setMemoryAlignment(config.byteAlignment)
+			manager.setEstimatedSwapTime(config.estimatedSwapTime.toInt())
+			manager.setWindowUploadCapacity(config.pipelineDepth)
+			manager.setMode(config.firmwareUpgradeMode)
+		}
+		manager.start(McuMgrImageSet().add(imageData), config?.eraseAppSettings ?: false)
 	}
 	/** Pause the firmware upgrade. */
 	fun pause() {

--- a/ios/Classes/SwiftMcumgrFlutterPlugin.swift
+++ b/ios/Classes/SwiftMcumgrFlutterPlugin.swift
@@ -175,7 +175,9 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
             throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call.debugDetails)
         }
         
-        try manager.update(data: args.firmwareData)
+        let config = args.hasConfiguration ? FirmwareUpgradeConfiguration(proto: args.configuration) : FirmwareUpgradeConfiguration()
+        
+        try manager.update(data: args.firmwareData, config: config)
     }
     
     private func kill(call: FlutterMethodCall) throws {

--- a/ios/Classes/UpdateManager.swift
+++ b/ios/Classes/UpdateManager.swift
@@ -32,9 +32,9 @@ class UpdateManager {
         self.logStreamHandler = logStreamHandler
     }
     
-    func update(data: Data) throws {
+    func update(data: Data, config: FirmwareUpgradeConfiguration) throws {
         dfuManager.logDelegate = updateLogger
-        try dfuManager.start(data: data)
+        try dfuManager.start(data: data, using: config)
     }
     
     func update(images: [(Int, Data)], config: FirmwareUpgradeConfiguration) throws {

--- a/ios/Classes/lib/proto/flutter_mcu.pb.swift
+++ b/ios/Classes/lib/proto/flutter_mcu.pb.swift
@@ -30,9 +30,20 @@ struct ProtoUpdateCallArgument {
 
   var firmwareData: Data = Data()
 
+  var configuration: ProtoFirmwareUpgradeConfiguration {
+    get {return _configuration ?? ProtoFirmwareUpgradeConfiguration()}
+    set {_configuration = newValue}
+  }
+  /// Returns true if `configuration` has been explicitly set.
+  var hasConfiguration: Bool {return self._configuration != nil}
+  /// Clears the value of `configuration`. Subsequent reads from it will return its default value.
+  mutating func clearConfiguration() {self._configuration = nil}
+
   var unknownFields = SwiftProtobuf.UnknownStorage()
 
   init() {}
+
+  fileprivate var _configuration: ProtoFirmwareUpgradeConfiguration? = nil
 }
 
 struct ProtoError {
@@ -195,7 +206,7 @@ struct ProtoUpdateStateChanges {
 
 extension ProtoUpdateStateChanges.FirmwareUpgradeState: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [ProtoUpdateStateChanges.FirmwareUpgradeState] = [
+  static let allCases: [ProtoUpdateStateChanges.FirmwareUpgradeState] = [
     .none,
     .validate,
     .upload,
@@ -308,7 +319,7 @@ struct ProtoFirmwareUpgradeConfiguration {
 
 extension ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment] = [
+  static let allCases: [ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment] = [
     .disabled,
     .twoByte,
     .fourByte,
@@ -319,7 +330,7 @@ extension ProtoFirmwareUpgradeConfiguration.ImageUploadAlignment: CaseIterable {
 
 extension ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode] = [
+  static let allCases: [ProtoFirmwareUpgradeConfiguration.FirmwareUpgradeMode] = [
     .testOnly,
     .confirmOnly,
     .testAndConfirm,
@@ -530,7 +541,7 @@ struct ProtoLogMessage {
 
 extension ProtoLogMessage.LogCategory: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [ProtoLogMessage.LogCategory] = [
+  static let allCases: [ProtoLogMessage.LogCategory] = [
     .transport,
     .config,
     .crash,
@@ -546,7 +557,7 @@ extension ProtoLogMessage.LogCategory: CaseIterable {
 
 extension ProtoLogMessage.LogLevel: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  static var allCases: [ProtoLogMessage.LogLevel] = [
+  static let allCases: [ProtoLogMessage.LogLevel] = [
     .debug,
     .verbose,
     .info,
@@ -614,6 +625,7 @@ extension ProtoUpdateCallArgument: SwiftProtobuf.Message, SwiftProtobuf._Message
   static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "device_uuid"),
     2: .standard(proto: "firmware_data"),
+    3: .same(proto: "configuration"),
   ]
 
   mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
@@ -624,24 +636,33 @@ extension ProtoUpdateCallArgument: SwiftProtobuf.Message, SwiftProtobuf._Message
       switch fieldNumber {
       case 1: try { try decoder.decodeSingularStringField(value: &self.deviceUuid) }()
       case 2: try { try decoder.decodeSingularBytesField(value: &self.firmwareData) }()
+      case 3: try { try decoder.decodeSingularMessageField(value: &self._configuration) }()
       default: break
       }
     }
   }
 
   func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+    // The use of inline closures is to circumvent an issue where the compiler
+    // allocates stack space for every if/case branch local when no optimizations
+    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+    // https://github.com/apple/swift-protobuf/issues/1182
     if !self.deviceUuid.isEmpty {
       try visitor.visitSingularStringField(value: self.deviceUuid, fieldNumber: 1)
     }
     if !self.firmwareData.isEmpty {
       try visitor.visitSingularBytesField(value: self.firmwareData, fieldNumber: 2)
     }
+    try { if let v = self._configuration {
+      try visitor.visitSingularMessageField(value: v, fieldNumber: 3)
+    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   static func ==(lhs: ProtoUpdateCallArgument, rhs: ProtoUpdateCallArgument) -> Bool {
     if lhs.deviceUuid != rhs.deviceUuid {return false}
     if lhs.firmwareData != rhs.firmwareData {return false}
+    if lhs._configuration != rhs._configuration {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }

--- a/lib/proto/flutter_mcu.pb.dart
+++ b/lib/proto/flutter_mcu.pb.dart
@@ -23,6 +23,7 @@ class ProtoUpdateCallArgument extends $pb.GeneratedMessage {
   factory ProtoUpdateCallArgument({
     $core.String? deviceUuid,
     $core.List<$core.int>? firmwareData,
+    ProtoFirmwareUpgradeConfiguration? configuration,
   }) {
     final $result = create();
     if (deviceUuid != null) {
@@ -30,6 +31,9 @@ class ProtoUpdateCallArgument extends $pb.GeneratedMessage {
     }
     if (firmwareData != null) {
       $result.firmwareData = firmwareData;
+    }
+    if (configuration != null) {
+      $result.configuration = configuration;
     }
     return $result;
   }
@@ -40,6 +44,7 @@ class ProtoUpdateCallArgument extends $pb.GeneratedMessage {
   static final $pb.BuilderInfo _i = $pb.BuilderInfo(_omitMessageNames ? '' : 'ProtoUpdateCallArgument', createEmptyInstance: create)
     ..aOS(1, _omitFieldNames ? '' : 'deviceUuid')
     ..a<$core.List<$core.int>>(2, _omitFieldNames ? '' : 'firmwareData', $pb.PbFieldType.OY)
+    ..aOM<ProtoFirmwareUpgradeConfiguration>(3, _omitFieldNames ? '' : 'configuration', subBuilder: ProtoFirmwareUpgradeConfiguration.create)
     ..hasRequiredFields = false
   ;
 
@@ -81,6 +86,17 @@ class ProtoUpdateCallArgument extends $pb.GeneratedMessage {
   $core.bool hasFirmwareData() => $_has(1);
   @$pb.TagNumber(2)
   void clearFirmwareData() => clearField(2);
+
+  @$pb.TagNumber(3)
+  ProtoFirmwareUpgradeConfiguration get configuration => $_getN(2);
+  @$pb.TagNumber(3)
+  set configuration(ProtoFirmwareUpgradeConfiguration v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasConfiguration() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearConfiguration() => clearField(3);
+  @$pb.TagNumber(3)
+  ProtoFirmwareUpgradeConfiguration ensureConfiguration() => $_ensure(2);
 }
 
 class ProtoError extends $pb.GeneratedMessage {

--- a/lib/proto/flutter_mcu.pbjson.dart
+++ b/lib/proto/flutter_mcu.pbjson.dart
@@ -19,13 +19,16 @@ const ProtoUpdateCallArgument$json = {
   '2': [
     {'1': 'device_uuid', '3': 1, '4': 1, '5': 9, '10': 'deviceUuid'},
     {'1': 'firmware_data', '3': 2, '4': 1, '5': 12, '10': 'firmwareData'},
+    {'1': 'configuration', '3': 3, '4': 1, '5': 11, '6': '.ProtoFirmwareUpgradeConfiguration', '10': 'configuration'},
   ],
 };
 
 /// Descriptor for `ProtoUpdateCallArgument`. Decode as a `google.protobuf.DescriptorProto`.
 final $typed_data.Uint8List protoUpdateCallArgumentDescriptor = $convert.base64Decode(
     'ChdQcm90b1VwZGF0ZUNhbGxBcmd1bWVudBIfCgtkZXZpY2VfdXVpZBgBIAEoCVIKZGV2aWNlVX'
-    'VpZBIjCg1maXJtd2FyZV9kYXRhGAIgASgMUgxmaXJtd2FyZURhdGE=');
+    'VpZBIjCg1maXJtd2FyZV9kYXRhGAIgASgMUgxmaXJtd2FyZURhdGESSAoNY29uZmlndXJhdGlv'
+    'bhgDIAEoCzIiLlByb3RvRmlybXdhcmVVcGdyYWRlQ29uZmlndXJhdGlvblINY29uZmlndXJhdG'
+    'lvbg==');
 
 @$core.Deprecated('Use protoErrorDescriptor instead')
 const ProtoError$json = {

--- a/lib/proto/flutter_mcu.proto
+++ b/lib/proto/flutter_mcu.proto
@@ -4,8 +4,9 @@ option java_package = "no.nordicsemi.android.mcumgr_flutter.gen";
 
 // Flutter call arguments
 message ProtoUpdateCallArgument {
-  string device_uuid = 1;
-  bytes firmware_data = 2;
+    string device_uuid = 1;
+    bytes firmware_data = 2;
+    ProtoFirmwareUpgradeConfiguration configuration = 3;
 }
 
 message ProtoError {

--- a/lib/src/mcumgr_flutter.dart
+++ b/lib/src/mcumgr_flutter.dart
@@ -73,7 +73,10 @@ abstract class FirmwareUpdateManager {
   /// Start update process.
   ///
   /// This is the simplified API to start DFU update for single image.
-  Future<void> updateWithImageData({required Uint8List image});
+  Future<void> updateWithImageData({
+    required Uint8List image,
+    FirmwareUpgradeConfiguration? configuration,
+  });
 
   /// Pause the update process.
   Future<void> pause();

--- a/lib/src/mcumgr_update_logger.dart
+++ b/lib/src/mcumgr_update_logger.dart
@@ -54,7 +54,7 @@ class McuMgrLogger extends FirmwareUpdateLogger {
         .map((event) => ProtoLogMessageStreamArg.fromBuffer(event))
         .where((event) => event.uuid == _deviceId)
         .listen((data) {
-      if (data.hasError()) {
+      if (data.hasError() && !_logMessageStreamController.isClosed) {
         _logMessageStreamController.addError(data.error.localizedDescription);
       }
 
@@ -62,7 +62,7 @@ class McuMgrLogger extends FirmwareUpdateLogger {
         _logMessageStreamController.close();
       }
 
-      if (data.hasProtoLogMessage()) {
+      if (data.hasProtoLogMessage() && !_logMessageStreamController.isClosed) {
         _logMessageStreamController.add(data.protoLogMessage.convent());
       }
     });

--- a/lib/src/mcumgr_update_manager.dart
+++ b/lib/src/mcumgr_update_manager.dart
@@ -99,13 +99,17 @@ class DeviceUpdateManager extends FirmwareUpdateManager {
           ).writeToBuffer());
 
   @override
-  Future<void> updateWithImageData({required Uint8List image}) {
-    final model = ProtoUpdateCallArgument()
-      ..deviceUuid = _deviceId
-      ..firmwareData = image;
-
+  Future<void> updateWithImageData({
+    required Uint8List image,
+    FirmwareUpgradeConfiguration? configuration,
+  }) {
     return methodChannel.invokeMethod(
-        UpdateManagerMethod.updateSingleImage.rawValue, model.writeToBuffer());
+        UpdateManagerMethod.updateSingleImage.rawValue,
+        ProtoUpdateCallArgument(
+          deviceUuid: _deviceId,
+          firmwareData: image,
+          configuration: configuration?.proto(),
+        ).writeToBuffer());
   }
 
   @override


### PR DESCRIPTION
Currently only the multi image firmware upgrade method allows to pass a configuration with it. The single image update only accepts the image data. This leads to different default settings on the platforms (e.g. erase app settings in false on android but true on iOS).  This PR also adds an optional configuration parameter to the single image update method.