### PR TITLE
fix: when ios update with images upgrade configuration always use def…

### DIFF
--- a/ios/Classes/UpdateManager.swift
+++ b/ios/Classes/UpdateManager.swift
@@ -42,7 +42,7 @@ class UpdateManager {
     
     func update(images: [ImageManager.Image], config: FirmwareUpgradeConfiguration) throws {
         dfuManager.logDelegate = updateLogger
-        try dfuManager.start(images: images)
+        try dfuManager.start(images: images, using: config)
     }
     
     func pause() {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
when ios update with images upgrade configuration always use default configuration, because no custom configuration are passed into the method at all