### PR TITLE
Fixed bug with iOS not respecting update configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+Fix bug on iOS that was not passing the `FirmwareUpgradeConfiguration` object to a certain `UpdateManager.update` overload.
+- This caused iOS to not adhere to settings that were provided via flutter code such as clearing app settings on the device.
+
 ## 0.4.1
 Prevent request Bluetooth permission on iOS until it is required (#81):
 

--- a/ios/Classes/UpdateManager.swift
+++ b/ios/Classes/UpdateManager.swift
@@ -42,7 +42,7 @@ class UpdateManager {
     
     func update(images: [ImageManager.Image], config: FirmwareUpgradeConfiguration) throws {
         dfuManager.logDelegate = updateLogger
-        try dfuManager.start(images: images)
+        try dfuManager.start(images: images, using: config)
     }
     
     func pause() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mcumgr_flutter
 description: nRF Connect Device Manager library is a Flutter plugin based on
   Android and iOS nRF Connect Device Manager libraries.
-version: 0.4.1
+version: 0.4.2
 homepage: "https://github.com/NordicSemiconductor/Flutter-nRF-Connect-Device-Manager"
 
 environment:


### PR DESCRIPTION
When using the method `FirmwareUpdateManager.update` on iOS devices, the `configuration` option was not being passed into the underlying `update` call. This in turn meant all configuration options provided by any flutter code would not be passed in. This is particularly problematic when attempting to keep the app settings on the firmware device as the default is to erase them.

This fixes the problem by simply passing the configuration object down to the SDK level correctly in the one spot it wasn't.