### PR TITLE
fix(ios): serialize FlutterMethodCall before passing to Flutter

### DIFF
--- a/ios/Classes/Extensions/FlutterError+Ext.swift
+++ b/ios/Classes/Extensions/FlutterError+Ext.swift
@@ -9,6 +9,6 @@ import Foundation
 
 extension FlutterError: Error {
     convenience init(error: Error, code: ErrorCode = .platformError, call: FlutterMethodCall? = nil) {
-        self.init(code: code.rawValue, message: error.localizedDescription, details: call)
+        self.init(code: code.rawValue, message: error.localizedDescription, details: call?.debugDetails)
     }
 }


### PR DESCRIPTION
Fix crash in `FlutterError` convenience init where the raw `FlutterMethodCall`
object was passed as 'details' parameter. Flutter's standard method codec
cannot serialize `FlutterMethodCall` objects, causing an assertion failure
in `WriteValueOfType()` when encoding error envelopes.

Now uses `call?.debugDetails` to convert to a serializable `[String: Any]`
dictionary, consistent with all other `FlutterError` usages in the codebase.

Fixes SIGABRT crash in `readImages()` when *iOSMcuManagerLibrary* returns an error.