### PR TITLE
fix(ios): ensure Flutter event channels are called on main thread

### DIFF
--- a/ios/Classes/FsManagerPlugin.swift
+++ b/ios/Classes/FsManagerPlugin.swift
@@ -113,31 +113,40 @@ private class FileDownloadDelegateImpl : FileDownloadDelegate {
     /// - parameter fileSize:        The overall size of the file being downloaded.
     /// - parameter timestamp:       The time this response packet was received.
     func downloadProgressDidChange(bytesDownloaded: Int, fileSize: Int, timestamp: Date) {
-        streamHandler.onEvent(
-            OnDownloadProgressChangedEvent(
-                current: Int64(bytesDownloaded),
-                total: Int64(fileSize),
-                timestamp: timestamp.asInt64,
-                remoteId: remoteId,
-                path: path
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.streamHandler.onEvent(
+                OnDownloadProgressChangedEvent(
+                    current: Int64(bytesDownloaded),
+                    total: Int64(fileSize),
+                    timestamp: timestamp.asInt64,
+                    remoteId: self.remoteId,
+                    path: self.path
+                )
             )
-        )
+        }
     }
     
     /// Called when an file download has failed.
     ///
     /// - parameter error: The error that caused the download to fail.
     func downloadDidFail(with error: Error) {
-        streamHandler.onEvent(
-            OnDownloadFailedEvent(cause: error.localizedDescription, remoteId: remoteId, path: path)
-        )
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.streamHandler.onEvent(
+                OnDownloadFailedEvent(cause: error.localizedDescription, remoteId: self.remoteId, path: self.path)
+            )
+        }
     }
     
     /// Called when the download has been cancelled.
     func downloadDidCancel() {
-        streamHandler.onEvent(
-            OnDownloadCancelledEvent(remoteId: remoteId, path: path)
-        )
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.streamHandler.onEvent(
+                OnDownloadCancelledEvent(remoteId: self.remoteId, path: self.path)
+            )
+        }
     }
     
     /// Called when the download has finished successfully.
@@ -145,9 +154,12 @@ private class FileDownloadDelegateImpl : FileDownloadDelegate {
     /// - parameter name: The file name.
     /// - parameter data: The file content.
     func download(of name: String, didFinish data: Data) {
-        streamHandler.onEvent(
-            OnDownloadCompletedEvent(remoteId: remoteId, path: path, bytes: FlutterStandardTypedData(bytes: data))
-        )
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.streamHandler.onEvent(
+                OnDownloadCompletedEvent(remoteId: self.remoteId, path: self.path, bytes: FlutterStandardTypedData(bytes: data))
+            )
+        }
     }
 }
 

--- a/ios/Classes/UpdateLogger.swift
+++ b/ios/Classes/UpdateLogger.swift
@@ -47,7 +47,9 @@ extension UpdateLogger: McuMgrLogDelegate {
         do {
             let container = ProtoLogMessageStreamArg(uuid: identifier, msg: log)
             let data = try container.serializedData()
-            logStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+            DispatchQueue.main.async { [weak self] in
+                self?.logStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+            }
         } catch let e {
             print(e.localizedDescription)
         }

--- a/ios/Classes/UpdateManager.swift
+++ b/ios/Classes/UpdateManager.swift
@@ -77,10 +77,14 @@ extension UpdateManager: FirmwareUpgradeDelegate {
             
             let arg = ProtoUpdateStateChangesStreamArg(updateStateChanges: changes, peripheral: peripheral)
             let data = try arg.serializedData()
-            stateStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+            }
         } catch let e {
             let error = FlutterError(error: e, code: ErrorCode.flutterTypeError)
-            stateStreamHandler.sink?(error)
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(error)
+            }
         }
     }
     
@@ -97,16 +101,19 @@ extension UpdateManager: FirmwareUpgradeDelegate {
         
         do {
             let statusData = try stateChangesArg.serializedData()
-            stateStreamHandler.sink?(FlutterStandardTypedData(bytes: statusData))
-            
             let progressData = try progressArg.serializedData()
-            progressStreamHandler.sink?(FlutterStandardTypedData(bytes: progressData))
-            
             let logData = try logArg.serializedData()
-            logStreamHandler.sink?(FlutterStandardTypedData(bytes: logData))
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(FlutterStandardTypedData(bytes: statusData))
+                self?.progressStreamHandler.sink?(FlutterStandardTypedData(bytes: progressData))
+                self?.logStreamHandler.sink?(FlutterStandardTypedData(bytes: logData))
+            }
         } catch let e {
             let error = FlutterError(error: e, code: ErrorCode.flutterTypeError)
-            stateStreamHandler.sink?(error)
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(error)
+            }
         }
     }
     
@@ -127,16 +134,19 @@ extension UpdateManager: FirmwareUpgradeDelegate {
         
         do {
             let data = try arg.serializedData()
-            stateStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
-            
             let progressData = try progressArg.serializedData()
-            progressStreamHandler.sink?(FlutterStandardTypedData(bytes: progressData))
-            
             let logData = try logArg.serializedData()
-            logStreamHandler.sink?(FlutterStandardTypedData(bytes: logData))
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+                self?.progressStreamHandler.sink?(FlutterStandardTypedData(bytes: progressData))
+                self?.logStreamHandler.sink?(FlutterStandardTypedData(bytes: logData))
+            }
         } catch let e {
             let error = FlutterError(error: e, code: ErrorCode.flutterTypeError)
-            stateStreamHandler.sink?(error)
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(error)
+            }
         }
     }
     
@@ -148,10 +158,15 @@ extension UpdateManager: FirmwareUpgradeDelegate {
             changes.newState = state.toProto()
             
             let arg = ProtoUpdateStateChangesStreamArg(updateStateChanges: changes, peripheral: peripheral)
-            stateStreamHandler.sink?(FlutterStandardTypedData(bytes: try arg.serializedData()))
+            let data = try arg.serializedData()
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(FlutterStandardTypedData(bytes: data))
+            }
         } catch let e {
             let error = FlutterError(error: e, code: ErrorCode.flutterTypeError)
-            stateStreamHandler.sink?(error)
+            DispatchQueue.main.async { [weak self] in
+                self?.stateStreamHandler.sink?(error)
+            }
         }
     }
     
@@ -165,10 +180,14 @@ extension UpdateManager: FirmwareUpgradeDelegate {
             let arg = ProtoProgressUpdateStreamArg(progressUpdate: progressUpdate, peripheral: peripheral)
             let data = try arg.serializedData()
             let flutterData = FlutterStandardTypedData(bytes: data)
-            progressStreamHandler.sink?(flutterData)
+            DispatchQueue.main.async { [weak self] in
+                self?.progressStreamHandler.sink?(flutterData)
+            }
         } catch let e {
             let error = FlutterError(error: e, code: ErrorCode.flutterTypeError)
-            progressStreamHandler.sink?(error)
+            DispatchQueue.main.async { [weak self] in
+                self?.progressStreamHandler.sink?(error)
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes crash with 'Unsupported value for standard codec' that occurred
during Bluetooth connect/disconnect events on iOS.

The iOS MCU manager library calls delegate methods from background threads,
but Flutter's platform channels (including event channels) must only be
accessed from the main thread on iOS. When accessed from background threads,
the StandardMessageCodec throws an exception causing the app to crash.

Changes:
- UpdateManager.swift: Wrapped all event sink calls in DispatchQueue.main.async
  for state changes, progress updates, completion, failure, and cancellation
- UpdateLogger.swift: Wrapped log message streaming in DispatchQueue.main.async
- FsManagerPlugin.swift: Wrapped all file download delegate callbacks in
  DispatchQueue.main.async for progress, completion, failure, and cancellation

All async blocks use [weak self] to prevent retain cycles and guard against
nil references.

See: https://docs.flutter.dev/platform-integration/platform-channels#channels-and-platform-threading
