### PR TITLE
Drop late events in update-state and progress streams after kill()

### DIFF
--- a/lib/src/mcumgr_update_manager.dart
+++ b/lib/src/mcumgr_update_manager.dart
@@ -147,8 +147,10 @@ class DeviceUpdateManager extends FirmwareUpdateManager {
         .map((event) => ProtoProgressUpdateStreamArg.fromBuffer(event))
         .where((event) => event.uuid == _deviceId)
         .where((event) => event.hasProgressUpdate())
-        .listen((event) =>
-            _progressStreamController.add(event.progressUpdate.convert()));
+        .listen((event) {
+      if (_progressStreamController.isClosed) return;
+      _progressStreamController.add(event.progressUpdate.convert());
+    });
   }
 
   void _setupUpdateStateStream() {
@@ -157,13 +159,20 @@ class DeviceUpdateManager extends FirmwareUpdateManager {
         .map((event) => ProtoUpdateStateChangesStreamArg.fromBuffer(event))
         .where((event) => event.uuid == _deviceId)
         .listen((data) async {
+      // Native side may emit late events after kill() has closed the
+      // controllers (e.g. when the user cancels mid-upload or the BLE
+      // adapter is turned off). Guard every controller mutation so we
+      // don't throw "Cannot add new events after calling close".
+      final stateController = _updateStateStreamController;
+      if (stateController == null || stateController.isClosed) return;
+
       if (data.hasError()) {
-        _updateStateStreamController!.addError(data.error.localizedDescription);
+        stateController.addError(data.error.localizedDescription);
         return;
       }
 
       if (data.done) {
-        _updateStateStreamController!.close();
+        await stateController.close();
         return;
       }
 
@@ -173,16 +182,19 @@ class DeviceUpdateManager extends FirmwareUpdateManager {
 
       final stateChanges = data.updateStateChanges;
       if (stateChanges.canceled) {
-        await _updateStateStreamController!.close();
+        await stateController.close();
         return;
       }
 
       var d = stateChanges.newState.convert();
 
-      _updateStateStreamController!.add(d);
+      stateController.add(d);
 
       if (d == FirmwareUpgradeState.upload) {
-        _updateInProgressStreamController!.add(true);
+        final inProgressController = _updateInProgressStreamController;
+        if (inProgressController != null && !inProgressController.isClosed) {
+          inProgressController.add(true);
+        }
       }
     });
   }


### PR DESCRIPTION
While integrating 0.8.1 into a firmware-update screen, I kept hitting an unhandled `Bad state: Cannot add new events after calling close` whenever `kill()` ran while an update was in flight. Reduced it down and traced it back to the listener bodies in `_setupUpdateStateStream` and `_setupProgressUpdateStream`.

## What goes wrong

The two listeners forward events from the platform broadcast stream into local stream controllers (`_updateStateStreamController`, `_progressStreamController`). `kill()` closes the local controllers, but doesn't cancel the underlying broadcast-stream subscriptions, so any event the platform emits in the window between "kill called" and "broadcast stream actually stops" lands on a closed controller and throws.

Sample stack:

```
Unhandled Exception: Bad state: Cannot add new events after calling close
#0  _BroadcastStreamController.addError (broadcast_stream_controller.dart:261)
#1  DeviceUpdateManager._setupUpdateStateStream.<anonymous closure> (mcumgr_update_manager.dart:161)
```

It's racy but reproducible on real hardware. We hit it the first time we wired up a Cancel button to the dialog.

## Reproduction

The `example/` app is enough.

1. Start an update.
2. Around the time the first progress events come through, call `manager.kill()` from app code. Wiring it to a debug button is the easiest way.
3. The unhandled exception above shows up in the Flutter console with `mcumgr_update_manager.dart:161` in the stack.

## Fix

Guard every controller mutation in the two listener bodies with `isClosed` checks. Late events get dropped silently after close, which is the right behaviour. Happy path is unchanged.

## Testing

Verified on a real Android device that the unhandled exception no longer fires when `kill()` is called mid-upload. The fix is platform-agnostic (Dart-only) so the same change applies on iOS.
