### PR TITLE
Expose erase(channel) method to flutter

### DIFF
--- a/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
+++ b/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/McumgrFlutterPlugin.kt
@@ -16,6 +16,7 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.runtime.mcumgr.McuMgrCallback
 import io.runtime.mcumgr.dfu.mcuboot.FirmwareUpgradeManager
 import io.runtime.mcumgr.exception.McuMgrException
+import io.runtime.mcumgr.response.img.McuMgrImageResponse
 import io.runtime.mcumgr.response.img.McuMgrImageStateResponse
 import no.nordicsemi.android.mcumgr_flutter.ext.toProto
 import io.runtime.mcumgr.managers.FsManager
@@ -138,6 +139,10 @@ class McumgrFlutterPlugin : FlutterPlugin, MethodCallHandler {
 
 				FlutterMethod.readImageList -> {
 					imageList(call, result)
+				}
+
+				FlutterMethod.erase -> {
+					erase(call, result)
 				}
 			}
 		} catch (e: FlutterError) {
@@ -304,5 +309,38 @@ class McumgrFlutterPlugin : FlutterPlugin, MethodCallHandler {
 		}
 
 		updateManager.imageManager.list(callback)
+	}
+
+	/** Erases the default secondary image slot or a specific raw image slot channel. */
+	private fun erase(@NonNull call: MethodCall, result: Result) {
+		val args = (call.arguments as? Map<*, *>).guard {
+			throw WrongArguments("Erase arguments expected")
+		}
+		val address = (args["deviceUuid"] as? String).guard {
+			throw WrongArguments("Device UUID expected")
+		}
+		val channel = (args["channel"] as? Number)?.toInt()
+		if (channel != null && channel < 0) {
+			throw WrongArguments("Channel must not be negative")
+		}
+		val updateManager = managers[address].guard {
+			throw UpdateManagerDoesNotExist("Update manager does not exist")
+		}
+
+		val callback = object : McuMgrCallback<McuMgrImageResponse> {
+			override fun onResponse(response: McuMgrImageResponse) {
+				result.success(null)
+			}
+
+			override fun onError(exception: McuMgrException) {
+				result.error("mcumgr_error", exception.message, null)
+			}
+		}
+
+		if (channel == null) {
+			updateManager.imageManager.erase(callback)
+		} else {
+			updateManager.imageManager.erase(channel, callback)
+		}
 	}
 }

--- a/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/utils/FlutterMethod.kt
+++ b/android/src/main/kotlin/no/nordicsemi/android/mcumgr_flutter/utils/FlutterMethod.kt
@@ -16,7 +16,8 @@ enum class FlutterMethod {
 	readLogs,
 	clearLogs,
 	kill,
-	readImageList;
+	readImageList,
+	erase;
 
 	companion object {
 		fun valueOfOrNull(string: String) = try {

--- a/darwin/Classes/SwiftMcumgrFlutterPlugin.swift
+++ b/darwin/Classes/SwiftMcumgrFlutterPlugin.swift
@@ -129,6 +129,8 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
                 result(nil)
             case .readImageList:
                 try readImages(call: call, result: result)
+            case .erase:
+                try erase(call: call, result: result)
             }
         } catch let e as FlutterError {
             result(e)
@@ -290,6 +292,35 @@ public class SwiftMcumgrFlutterPlugin: NSObject, FlutterPlugin {
             } catch {
                 result(FlutterError(error: error, call: call))
             }
+        }
+    }
+
+    /// Erases the default secondary image slot or a specific raw image slot channel.
+    private func erase(call: FlutterMethodCall, result: @escaping FlutterResult) throws {
+        guard let args = call.arguments as? [String: Any],
+              let uuid = args["deviceUuid"] as? String else {
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Can not parse erase arguments", details: call.debugDetails)
+        }
+
+        let channelValue = args["channel"]
+        let channel = (channelValue as? Int) ?? (channelValue as? NSNumber)?.intValue
+        if let channel, channel < 0 {
+            throw FlutterError(code: ErrorCode.wrongArguments.rawValue, message: "Channel must not be negative", details: call.debugDetails)
+        }
+
+        guard let manager = updateManagers[uuid] else {
+            throw FlutterError(code: ErrorCode.updateManagerDoesNotExist.rawValue, message: "Update manager does not exist", details: call.debugDetails)
+        }
+
+        let image = channel.map { $0 / 2 }
+        let slot = channel.map { $0 % 2 }
+        manager.imageManager.erase(image: image, slot: slot) { _, error in
+            if let error {
+                result(FlutterError(error: error, call: call))
+                return
+            }
+
+            result(nil)
         }
     }
 }

--- a/darwin/Classes/Utils/Methods.swift
+++ b/darwin/Classes/Utils/Methods.swift
@@ -22,6 +22,7 @@ public enum FlutterMethod: String {
     case readLogs
     case clearLogs
     case readImageList
+    case erase
 }
 
 /// Methods which platform sends to Flutter

--- a/lib/src/mcumgr_flutter.dart
+++ b/lib/src/mcumgr_flutter.dart
@@ -109,6 +109,16 @@ abstract class FirmwareUpdateManager {
 
   /// Read current image list from the device.
   Future<List<ImageSlot>?> readImageList();
+
+  /// Erase an image slot on the device.
+  ///
+  /// When [channel] is omitted, the device erases its default secondary image
+  /// slot. When [channel] is provided, the command targets that raw image slot
+  /// channel.
+  ///
+  /// The command fails on the device if the target slot contains a confirmed
+  /// image, an image pending test on next reboot, or an active split-image slot.
+  Future<void> erase([int? channel]);
 }
 
 abstract class FirmwareUpdateLogger {

--- a/lib/src/mcumgr_update_manager.dart
+++ b/lib/src/mcumgr_update_manager.dart
@@ -230,4 +230,16 @@ class DeviceUpdateManager extends FirmwareUpdateManager {
       return null;
     }
   }
+
+  @override
+  Future<void> erase([int? channel]) async {
+    if (channel != null && channel < 0) {
+      throw ArgumentError.value(channel, 'channel', 'must not be negative');
+    }
+
+    await methodChannel.invokeMethod(UpdateManagerMethod.erase.rawValue, {
+      'deviceUuid': _deviceId,
+      'channel': channel,
+    });
+  }
 }

--- a/lib/src/mcumgr_web_manager.dart
+++ b/lib/src/mcumgr_web_manager.dart
@@ -180,6 +180,13 @@ class WebUpdateManager extends FirmwareUpdateManager {
   Future<List<ImageSlot>?> readImageList() async {
     return [];
   }
+
+  @override
+  Future<void> erase([int? channel]) {
+    throw UnimplementedError(
+      "erase is not supported on web.",
+    );
+  }
 }
 
 // Interop Extensions

--- a/lib/src/mcumgr_web_manager_stub.dart
+++ b/lib/src/mcumgr_web_manager_stub.dart
@@ -80,4 +80,9 @@ class WebUpdateManager extends FirmwareUpdateManager {
   Future<List<ImageSlot>?> readImageList() {
     throw UnimplementedError();
   }
+
+  @override
+  Future<void> erase([int? channel]) {
+    throw UnimplementedError();
+  }
 }

--- a/lib/src/method_channels.dart
+++ b/lib/src/method_channels.dart
@@ -39,6 +39,7 @@ class UpdateManagerMethod {
   static const cancel = const UpdateManagerMethod('cancel');
   static const kill = const UpdateManagerMethod('kill');
   static const readImageList = const UpdateManagerMethod('readImageList');
+  static const erase = const UpdateManagerMethod('erase');
 }
 
 /// Channel methods related to Logger


### PR DESCRIPTION
# Expose erase(channel) method to flutter

## Problem
Sometimes, FOTA get's stuck due to an image being stuck in an image slot that can't be verified or moved. Updating to other firmwares is also not possible in this case, as the slot already has a pending image. The only way I was able to recover from these situations, is to erase the secondary image slot and update again to a working firmware. The Android and iOS libraries already support this, but the function was not exposed to flutter.

## Solution
Bridge `ImageManager.erase(channel, callback)` to flutter as `FirmwareUpdateManager.erase(channel)`.

## Usage

```dart
final updateManager =
    await FirmwareUpdateManagerFactory().getUpdateManager(deviceId);

// Erase the default secondary image slot.
await updateManager.erase();

// Erase a specific raw image slot/channel.
// For example, channel 1 usually refers to the secondary slot for image 0.
await updateManager.erase(1);

// Erase another image slot/channel, useful for multi-image devices.
await updateManager.erase(3);
```

## Compatibility

- Fully backward compatible — additive only, no existing APIs changed
- No new native dependencies — uses existing ImageManager already instantiated