### PR TITLE
Add pre-load caching script to web (avoid double device picker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,19 @@ nRF Connect Device Manager library is a Flutter plugin (aka "wrapper") around th
 [![GitHub forks](https://img.shields.io/github/forks/nordicsemi/Flutter-nRF-Connect-Device-Manager)](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/members)
 [![GitHub contributors](https://img.shields.io/github/contributors/nordicsemi/Flutter-nRF-Connect-Device-Manager)](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/graphs/contributors)
 
-___
+---
+
 ## Supported Platforms
+
 - Android: `minSdkVersion 21`
 - iOS: `13.0`
 - macOS: `10.15`
 - Web: Chrome 56+ (Web Bluetooth required)
 
 ## Getting Started
+
 ### Creating a manager
+
 Use `UpdateManagerFactory` to create an instance of `FirmwareUpdateManager`:
 
 ```dart
@@ -29,6 +33,7 @@ final updateStream = updateManager.setup();
 ```
 
 ### Updating the device
+
 To update the device, call `update` method on the `FirmwareUpdateManager` instance:
 
 ```dart
@@ -62,6 +67,7 @@ await updateManager.updateWithImageData(image: fwImage!);
 > `update` and `updateWithImageData` methods are asynchronous, however, they do not return a result of the update process. They only start the update process. To listen for updates, subscribe to the `updateStream` and `progressStream`. See also [Issue #63](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/issues/63) for more information.
 
 ### Listening for updates
+
 To listen for updates, subscribe to the `updateStream` and `progressStream`:
 
 ```dart
@@ -79,6 +85,7 @@ updateManager.progressStream.listen((event) {
 ```
 
 ### Controlling the update
+
 To control the update, use `FirmwareUpdateManager` methods:
 
 ```dart
@@ -99,6 +106,7 @@ To control the update, use `FirmwareUpdateManager` methods:
 ```
 
 ### Killing the manager
+
 After the update is finished, call `kill` to kill the manager, otherwise it will lead to memory leaks and other issues:
 
 ```dart
@@ -106,6 +114,7 @@ updateManager.kill();
 ```
 
 ### Reading image list
+
 To read the current image list (installed firmware slots) from the device:
 
 ```dart
@@ -113,6 +122,7 @@ List<ImageSlot>? slots = await updateManager.readImageList();
 ```
 
 ### Confirming an image
+
 When using `FirmwareUpgradeMode.testOnly`, the new firmware runs without being confirmed. Use `confirmImage` to permanently mark it as the active image after your own validation:
 
 ```dart
@@ -124,6 +134,7 @@ await updateManager.confirmImage(activeSlot.hash);
 If `confirmImage` is not called before the next reboot, the bootloader will revert to the previous firmware.
 
 ## Reading logs
+
 To listen for logs, subscribe to the `logger.logMessageStream`:
 
 ```dart
@@ -142,6 +153,7 @@ List<McuLogMessage> logs =
 ```
 
 ## Web Setup
+
 Web support uses the [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API), which is currently supported in Chrome and Chrome-based browsers. It requires a **secure context** (HTTPS or `localhost`).
 
 ### Required: Add script tag to `web/index.html`
@@ -157,16 +169,12 @@ Add the following `<script>` tag to your app's `web/index.html` **before** `flut
 
 Without this script, the browser will show a second Bluetooth device picker when the firmware update starts.
 
-### Web behaviour differences
-- The `deviceId` passed to `getUpdateManager()` must be the browser-assigned opaque device UUID (not a MAC address).
-- MAC addresses are intentionally hidden by the Web Bluetooth API and cannot be retrieved.
-- `readImageList()`, `confirmImage()`, and `erase()` are not supported on web and will throw `UnimplementedError`.
-- `pause()` and `resume()` are no-ops on web.
-
 ## Settings Manager
+
 The Settings Manager provides functionality to read and write device configuration settings via the MCU Manager protocol.
 
 ### Creating a Settings Manager
+
 ```dart
 import 'package:mcumgr_flutter/mcumgr_flutter.dart';
 
@@ -174,6 +182,7 @@ final mcumgrSettings = McumgrSettings();
 ```
 
 ### Initializing the Settings Manager
+
 Before using the settings manager, you must initialize it with the device address:
 
 ```dart
@@ -185,6 +194,7 @@ await mcumgrSettings.init(
 ```
 
 ### Reading Settings
+
 You can read all settings or a specific setting:
 
 ```dart
@@ -198,6 +208,7 @@ final rawBytes = await mcumgrSettings.readSetting('config/timeout/value');
 ```
 
 ### Writing Settings
+
 To write a setting:
 
 ```dart
@@ -210,6 +221,7 @@ await mcumgrSettings.writeSetting('feature/enabled', true);
 ```
 
 ### Decoding Setting Values
+
 Settings are returned as raw bytes (`Uint8List`). You need to decode them based on their expected type:
 
 ```dart
@@ -234,6 +246,7 @@ bool decodeBoolSetting(Uint8List bytes) {
 ```
 
 ### Disposing the Settings Manager
+
 When you're done using the settings manager:
 
 ```dart
@@ -241,6 +254,7 @@ await mcumgrSettings.dispose();
 ```
 
 ### Complete Example
+
 ```dart
 final mcumgrSettings = McumgrSettings();
 
@@ -259,7 +273,7 @@ try {
 
   // Write a setting
   await mcumgrSettings.writeSetting('device/name', 'NewDeviceName');
-  
+
 } catch (e) {
   print('Error: $e');
 } finally {

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 nRF Connect Device Manager library is a Flutter plugin (aka "wrapper") around the existing [Android](https://github.com/nordicsemi/Android-nRF-Connect-Device-Manager) and [iOS](https://github.com/nordicsemi/IOS-nRF-Connect-Device-Manager) nRF Connect Device Manager libraries. For more concrete documentation, you may also try reaching out into those for specific details.
 
-![Platforms](https://img.shields.io/badge/Platforms-Android%20|%20iOS%20|%20macOS-333333.svg)
+![Platforms](https://img.shields.io/badge/Platforms-Android%20|%20iOS%20|%20macOS%20|%20Web-333333.svg)
 [![License](https://img.shields.io/github/license/nordicsemi/Flutter-nRF-Connect-Device-Manager)](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/blob/main/LICENSE)
 [![Release](https://img.shields.io/github/release/nordicsemi/Flutter-nRF-Connect-Device-Manager.svg)](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/releases)
 [![GitHub stars](https://img.shields.io/github/stars/nordicsemi/Flutter-nRF-Connect-Device-Manager)](https://github.com/nordicsemi/Flutter-nRF-Connect-Device-Manager/stargazers)
@@ -13,7 +13,8 @@ ___
 ## Supported Platforms
 - Android: `minSdkVersion 21`
 - iOS: `13.0`
-- MacOS: `10.15`
+- macOS: `10.15`
+- Web: Chrome 56+ (Web Bluetooth required)
 
 ## Getting Started
 ### Creating a manager
@@ -139,6 +140,28 @@ To read logs from the device, use `readLog` method:
 List<McuLogMessage> logs =
         await updateManager.logger.readLogs(clearLogs: false);
 ```
+
+## Web Setup
+Web support uses the [Web Bluetooth API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API), which is currently supported in Chrome and Chrome-based browsers. It requires a **secure context** (HTTPS or `localhost`).
+
+### Required: Add script tag to `web/index.html`
+
+Add the following `<script>` tag to your app's `web/index.html` **before** `flutter_bootstrap.js`. This installs an intercept that caches the BLE device obtained during scanning so the firmware update flow can reuse it without prompting the user a second time.
+
+```html
+<body>
+  <script src="assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr_setup.js"></script>
+  <script src="flutter_bootstrap.js" async></script>
+</body>
+```
+
+Without this script, the browser will show a second Bluetooth device picker when the firmware update starts.
+
+### Web behaviour differences
+- The `deviceId` passed to `getUpdateManager()` must be the browser-assigned opaque device UUID (not a MAC address).
+- MAC addresses are intentionally hidden by the Web Bluetooth API and cannot be retrieved.
+- `readImageList()`, `confirmImage()`, and `erase()` are not supported on web and will throw `UnimplementedError`.
+- `pause()` and `resume()` are no-ops on web.
 
 ## Settings Manager
 The Settings Manager provides functionality to read and write device configuration settings via the MCU Manager protocol.

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -33,6 +33,7 @@
     <link rel="manifest" href="manifest.json" />
   </head>
   <body>
+    <script src="assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr_setup.js"></script>
     <script src="flutter_bootstrap.js" async></script>
   </body>
 </html>

--- a/lib/src/mcumgr_web/mcumgr.js
+++ b/lib/src/mcumgr_web/mcumgr.js
@@ -72,22 +72,30 @@ class MCUManager {
   async connect(filters) {
     try {
       this._device = await this._requestDevice(filters)
-      this._logger.info(`Connecting to device ${this.name}...`)
-      this._device.addEventListener('gattserverdisconnected', async (event) => {
-        this._logger.info(event)
-        if (!this._userRequestedDisconnect) {
-          this._logger.info('Trying to reconnect')
-          this._connect(this._reconnectDelay)
-        } else {
-          this._disconnected()
-        }
-      })
+      this._setupDisconnectListener()
       this._connect(0)
     } catch (error) {
       this._logger.error(error)
       await this._disconnected(error)
       return
     }
+  }
+  connectExisting(device) {
+    this._device = device
+    this._logger.info(`Connecting to existing device ${this.name}...`)
+    this._setupDisconnectListener()
+    this._connect(0)
+  }
+  _setupDisconnectListener() {
+    this._device.addEventListener('gattserverdisconnected', async (event) => {
+      this._logger.info(event)
+      if (!this._userRequestedDisconnect) {
+        this._logger.info('Trying to reconnect')
+        this._connect(this._reconnectDelay)
+      } else {
+        this._disconnected()
+      }
+    })
   }
   _connect(delay = 1000) {
     setTimeout(async () => {

--- a/lib/src/mcumgr_web/mcumgr_interop.js
+++ b/lib/src/mcumgr_web/mcumgr_interop.js
@@ -33,9 +33,9 @@ window.McuMgrFlutter = {
 
     return new Promise(async (resolve, reject) => {
       try {
-        // * get device
-        let targetDevice = null
-        if (navigator.bluetooth && navigator.bluetooth.getDevices) {
+        // * get device — use cache from mcumgr_setup.js, fall back to getDevices()
+        let targetDevice = window._mcumgrDeviceCache && window._mcumgrDeviceCache.get(deviceId)
+        if (!targetDevice && navigator.bluetooth && navigator.bluetooth.getDevices) {
           const devices = await navigator.bluetooth.getDevices()
           targetDevice = devices.find((d) => d.id === deviceId)
         }
@@ -95,13 +95,11 @@ window.McuMgrFlutter = {
           this._log(err ? `Disconnected with error: ${err}` : 'Disconnected.')
         })
 
-        if (targetDevice) {
-          this._log(`Found paired device: ${targetDevice.name}`)
-          mgr._device = targetDevice
-          mgr._connect(0)
-        } else {
-          await mgr.connect()
+        if (!targetDevice) {
+          throw new Error(`Device ${deviceId} not found. Call McuMgrWebLoader.initialize() at app startup before scanning.`)
         }
+        this._log(`Found paired device: ${targetDevice.name}, connecting...`)
+        mgr.connectExisting(targetDevice)
 
         await new Promise((connResolve, connReject) => {
           if (mgr._characteristic) {

--- a/lib/src/mcumgr_web/mcumgr_setup.js
+++ b/lib/src/mcumgr_web/mcumgr_setup.js
@@ -1,0 +1,24 @@
+;(function () {
+  if (!navigator.bluetooth || window._mcumgrSetupDone) return
+  window._mcumgrSetupDone = true
+  window._mcumgrDeviceCache = new Map()
+
+  const SMP_SERVICE_UUID = '8d53dc1d-1db7-4cd3-868b-8a527460aa84'
+
+  const _original = navigator.bluetooth.requestDevice.bind(navigator.bluetooth)
+  navigator.bluetooth.requestDevice = async function (options, ...rest) {
+    // Ensure the SMP service is always in optionalServices so MCUmgr can access it
+    if (options) {
+      options.optionalServices = options.optionalServices || []
+      if (!options.optionalServices.includes(SMP_SERVICE_UUID)) {
+        options.optionalServices.push(SMP_SERVICE_UUID)
+      }
+    }
+    const device = await _original(options, ...rest)
+    if (device && device.id) {
+      window._mcumgrDeviceCache.set(device.id, device)
+      console.log(`[McuMgr] Cached BLE device: ${device.id} (${device.name})`)
+    }
+    return device
+  }
+})()

--- a/lib/src/mcumgr_web_loader.dart
+++ b/lib/src/mcumgr_web_loader.dart
@@ -3,56 +3,55 @@ import 'dart:async';
 import 'package:web/web.dart' as web;
 
 class McuMgrWebLoader {
+  static bool _initialized = false;
+
+  /// Call once at app startup, before any BLE scanning, to install the
+  /// requestDevice intercept that caches BluetoothDevice objects.
+  static Future<void> initialize() async {
+    if (_initialized) return;
+    _initialized = true;
+    await _loadScript(
+      'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr_setup.js',
+    );
+  }
+
   static Future<void> loadJs() async {
     print('Attempting to load web scripts...');
-    if (web.document.querySelector('script[src*="mcumgr_interop.js"]') !=
-            null &&
+    if (web.document.querySelector('script[src*="mcumgr_interop.js"]') != null &&
         web.document.querySelector('script[src*="mcumgr.js"]') != null &&
         web.document.querySelector('script[src*="cbor.js"]') != null) {
       print('All mcumgr scripts already loaded');
       return;
     }
 
+    final v = DateTime.now().millisecondsSinceEpoch;
+    await _loadScript(
+      'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/cbor.js?v=$v',
+    );
+    await _loadScript(
+      'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr.js?v=$v',
+    );
+    await _loadScript(
+      'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr_interop.js?v=$v',
+      type: 'module',
+    );
+  }
+
+  static Future<void> _loadScript(String src, {String? type}) {
     final completer = Completer<void>();
-
-    // Helper to load a script
-    Future<void> loadScript(String src, {String? type}) {
-      final scriptCompleter = Completer<void>();
-      final web.HTMLScriptElement script =
-          web.document.createElement('script') as web.HTMLScriptElement;
-      script.src = src;
-      if (type != null) script.type = type;
-
-      script.onLoad.listen((_) {
-        print('Loaded script: $src');
-        scriptCompleter.complete();
-      });
-      script.onError.listen((e) {
-        print('Failed to load script: $src');
-        scriptCompleter.completeError('Failed to load $src');
-      });
-
-      web.document.head!.appendChild(script);
-      return scriptCompleter.future;
-    }
-
-    try {
-      await loadScript(
-        'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/cbor.js',
-      );
-      await loadScript(
-        'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr.js',
-      );
-      await loadScript(
-        'assets/packages/mcumgr_flutter/lib/src/mcumgr_web/mcumgr_interop.js',
-        type: 'module',
-      );
-
+    final script =
+        web.document.createElement('script') as web.HTMLScriptElement;
+    script.src = src;
+    if (type != null) script.type = type;
+    script.onLoad.listen((_) {
+      print('Loaded script: $src');
       completer.complete();
-    } catch (e) {
-      completer.completeError(e);
-    }
-
+    });
+    script.onError.listen((e) {
+      print('Failed to load script: $src');
+      completer.completeError('Failed to load $src');
+    });
+    web.document.head!.appendChild(script);
     return completer.future;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ flutter:
 
   assets:
     - assets/mock_logs.txt
+    - lib/src/mcumgr_web/mcumgr_setup.js
     - lib/src/mcumgr_web/mcumgr_interop.js
     - lib/src/mcumgr_web/mcumgr.js
     - lib/src/mcumgr_web/cbor.js


### PR DESCRIPTION
Web QoL/Bug fix
- User can add script to their index.html to pre-load and override the requestDevices method
- It falls back to clicking the device twice if they don't do this